### PR TITLE
Fix util class doesn't exist

### DIFF
--- a/src/settings/fields/url.php
+++ b/src/settings/fields/url.php
@@ -64,7 +64,7 @@ class url extends field {
 					sprintf(
 						'%s %s',
 						$this->get( 'label_for' ),
-						util::localize( 'Not a valid URL' ) ) );
+						\owaWp\util::localize( 'Not a valid URL' ) ) );
 		}		
 	}
 	


### PR DESCRIPTION
Was using the extension on PHP 7.3 and found out this error when specifying a bad URL : 
`Fatal error: Uncaught Error: Class 'owaWp\settings\fields\util' not found in /var/www/html/wordpress/wp-content/plugins/open-web-analytics/src/settings/fields/url.php:67 Stack trace: #0 /var/www/html/wordpress/wp-content/plugins/open-web-analytics/src/settings/page.php(138): owaWp\settings\fields\url->isValid('') #1 /var/www/html/wordpress/wp-includes/class-wp-hook.php(309): owaWp\settings\page->validateAndSanitize(Array) #2 /var/www/html/wordpress/wp-includes/plugin.php(189): WP_Hook->apply_filters(Array, Array) #3 /var/www/html/wordpress/wp-includes/formatting.php(4976): apply_filters('sanitize_option...', Array, 'owa_wp', Array) #4 /var/www/html/wordpress/wp-includes/option.php(421): sanitize_option('owa_wp', Array) #5 /var/www/html/wordpress/wp-admin/options.php(322): update_option('owa_wp', Array) #6 {main} thrown in /var/www/html/wordpress/wp-content/plugins/open-web-analytics/src/settings/fields/url.php on line 67`

So here is the fix.